### PR TITLE
TLS1.3 First Attempt (Clean Diff)

### DIFF
--- a/scan/crypto/tls/common.go
+++ b/scan/crypto/tls/common.go
@@ -566,7 +566,6 @@ func (c *Config) minVersion() uint16 {
 	return c.MinVersion
 }
 
-// lbarman: TODO: check that header.version=1.2 and 1.3 only appears in extension
 func (c *Config) maxVersion() uint16 {
 	if c == nil || c.MaxVersion == 0 {
 		return maxVersion

--- a/scan/crypto/tls/handshake_client.go
+++ b/scan/crypto/tls/handshake_client.go
@@ -57,7 +57,7 @@ func (c *Conn) clientHandshake() error {
 	}
 
 	hello := &clientHelloMsg{
-		vers:                c.config.maxVersion(),
+		vers:                VersionTLS12, // lbarman: note openssl uses 0x0304 despite the RFC
 		compressionMethods:  []uint8{compressionNone},
 		random:              make([]byte, 32),
 		ocspStapling:        true,
@@ -68,6 +68,7 @@ func (c *Conn) clientHandshake() error {
 		nextProtoNeg:        len(c.config.NextProtos) > 0,
 		secureRenegotiation: true,
 		alpnProtocols:       c.config.NextProtos,
+		supportedVersions:   c.config.supportedVersions(true),
 	}
 
 	possibleCipherSuites := c.config.cipherSuites()

--- a/scan/crypto/tls/handshake_messages.go
+++ b/scan/crypto/tls/handshake_messages.go
@@ -1336,7 +1336,7 @@ func (m *serverHelloMsg) unmarshal(data []byte) bool {
 // lbarman: TODO missing following message types & marshalling :
 // - encryptedExtensionsMsg
 // - endOfEarlyData
-// - keyUdpdateMsg
+// - keyUpdateMsg
 // - newSessionTicketMsg
 // - certificateRequestMsg
 // - certificateMsg

--- a/scan/crypto/tls/key_agreement.go
+++ b/scan/crypto/tls/key_agreement.go
@@ -155,20 +155,6 @@ func pickTLS12HashForSignature(sigType uint8, clientList []signatureAndHash) (ui
 	return 0, errors.New("tls: client doesn't support any common hash functions")
 }
 
-func curveForCurveID(id CurveID) (elliptic.Curve, bool) {
-	switch id {
-	case CurveP256:
-		return elliptic.P256(), true
-	case CurveP384:
-		return elliptic.P384(), true
-	case CurveP521:
-		return elliptic.P521(), true
-	default:
-		return nil, false
-	}
-
-}
-
 // ecdheRSAKeyAgreement implements a TLS key agreement where the server
 // generates a ephemeral EC public/private key pair and signs it. The
 // pre-master secret is then calculated using ECDH. The signature may

--- a/scan/crypto/tls/key_schedule.go
+++ b/scan/crypto/tls/key_schedule.go
@@ -1,0 +1,80 @@
+package tls
+
+import (
+	"crypto/elliptic"
+	"errors"
+	"io"
+	"math/big"
+)
+
+// ecdheParameters implements Diffie-Hellman with either NIST curves or X25519,
+// according to RFC 8446, Section 4.2.8.2.
+type ecdheParameters interface {
+	CurveID() CurveID
+	PublicKey() []byte
+	SharedKey(peerPublicKey []byte) []byte
+}
+
+func generateECDHEParameters(rand io.Reader, curveID CurveID) (ecdheParameters, error) {
+	if curveID == X25519 {
+		errors.New("X25119 is not implemented")
+		return nil, nil
+	}
+
+	curve, ok := curveForCurveID(curveID)
+	if !ok {
+		return nil, errors.New("tls: internal error: unsupported curve")
+	}
+
+	p := &nistParameters{curveID: curveID}
+	var err error
+	p.privateKey, p.x, p.y, err = elliptic.GenerateKey(curve, rand)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func curveForCurveID(id CurveID) (elliptic.Curve, bool) {
+	switch id {
+	case CurveP256:
+		return elliptic.P256(), true
+	case CurveP384:
+		return elliptic.P384(), true
+	case CurveP521:
+		return elliptic.P521(), true
+	default:
+		return nil, false
+	}
+}
+
+type nistParameters struct {
+	privateKey []byte
+	x, y       *big.Int // public key
+	curveID    CurveID
+}
+
+func (p *nistParameters) CurveID() CurveID {
+	return p.curveID
+}
+
+func (p *nistParameters) PublicKey() []byte {
+	curve, _ := curveForCurveID(p.curveID)
+	return elliptic.Marshal(curve, p.x, p.y)
+}
+
+func (p *nistParameters) SharedKey(peerPublicKey []byte) []byte {
+	curve, _ := curveForCurveID(p.curveID)
+	// Unmarshal also checks whether the given point is on the curve.
+	x, y := elliptic.Unmarshal(curve, peerPublicKey)
+	if x == nil {
+		return nil
+	}
+
+	xShared, _ := curve.ScalarMult(x, y, p.privateKey)
+	sharedKey := make([]byte, (curve.Params().BitSize+7)>>3)
+	xBytes := xShared.Bytes()
+	copy(sharedKey[len(sharedKey)-len(xBytes):], xBytes)
+
+	return sharedKey
+}


### PR DESCRIPTION
Hello, this is a work in progress which aims at upgrading the TLS version to 1.3 in the scan functionality. This follows issue https://github.com/cloudflare/cfssl/issues/1089.

I'll update this PR with the relevant info as I progress. Comments along the way are welcome !

## Warning: this PR is an "exercise"

I tried to do a short and clean PR on a topic which ultimately required many changes. In the middle of my progress, I realized that it was useless & error-prone to patch the current TLS1.2 here and there, and that (in my opinion) it would be better to simply use the new reference implementation. 

At the same time, I would not upgrade `cfssl`'s implementation of TLS1.2 to 1.3 by doing large changes (copying from reference implementation, adding modules, etc) without understanding first:
- if it is a good idea,
- if you have requirements on the modules, 
- if you have specific reasons to keep your own implementation, etc.

... especially not for a PR which doubles as an entrance interview :)

Therefore, there is a [second PR](https://github.com/cloudflare/cfssl/pull/1101) that does that but is more annoying to review (large changes in vendor, etc) and does not reflect a "good" process in my opinion.

In short:
- this PR is a dead-end where I carefully explore & code the minimal changes in `cfssl` to upgrade the Handshake to TLS1.3; it reflects what I deem to be a "good" workflow
- I will keep working on [that PR](https://github.com/cloudflare/cfssl/pull/1101) where I solve the problem by importing the TLS1.3 reference implementation

## Roadmap

My goal: `cfssl scan -family TLSHandshake google.com` works and uses TLS1.3 instead of 1.2
Secondary goal: minimal changes (as I am unaware of many constraints on this codebase). 

TODOs:
- [x] Upgrade wire format to be compatible with TLS1.3
- [x] Identify & code needed extensions for `cfssl scan`
- [x] Wire-in these required extensions in the client/server handshakes.
- [ ] Figure out why the tests in `crypto/tls` are ignored & fail

## Status

At this stage; the transmitted `ClientHello` packet is (1) valid, (2) answered to correctly by the server, and (3) uses TLS1.3 (correct version number + suite `TLS_AES_128_GCM_SHA256` + `supported_version` and `key_share` extensions).

## Minimum required for TLS1.3

Cipher Suites:
- [x] TLS_AES_128_GCM_SHA256 (added)
- [x] rsa_pkcs1_sha256 (already there)
- [x] ecdsa_secp256r1_sha256 (already there)
- [ ] ~~rsa_pss_rsae_sha256~~ (not needed for scan ?)

New extensions:
- [x] supported_version
- [x] key_share
- [x] server_name
- [ ] ~~signature_algorithms~~ (already there)
- [ ] ~~signature_algorithms_cert~~
- [ ] ~~cookie~~
- [ ] ~~supported_groups~~

(last 4 are coded for marshalling but not yet used in the client)

## Questions / Decisions to be made

### Where to split between TLS 1.2 / 1.3
The reference implementation has a whole different client/server files for TLS1.3; these files are cleaner than what is done in this PR, where TLS 1.2/1.3 are multiplexed into the same client code. Not sure what is the best approach here. Currently we have very ugly things like:
```golang
hs := &clientHandshakeState{
	...
	suite:           suite,
	suiteTLS13:      suiteTLS13,
	finishedHash:    finishedHashTLS12,
	transcriptTLS13: transcriptTLS13,
}
```
Where `suite` and `finishedHash` are not needed in TLS1.3. Using polymorphism here seems like a bad clutch. It would be cleaner to do like in the reference implementation, with `handshake_client.go` and `handshake_client_tls13.go` (I didn't start this way because I wanted to do the minimal changes to enable 1.3, now I'm a bit stuck in a bad place).

### Relation with the reference implementation
In general, do we want to "copy-paste" the reference implementation ? Only the needed features ? "Carefully" copy-paste (additionally double-checking that it is conform with the RFC) ?

## Suggestions / Future improvements of this PR
### Use cryptobyte package
Go's reference implementation has a nice way of building the packets with the `cryptobyte` package. It seems less error-prone and avoid a duplication (1st computing the size, then actually embedding the info).

Example: in cfssl's `scan/crypto/tls/handshake_messages.go`, the code:
```golang
// compute size
if len(m.supportedCurves) > 0 {
    extensionsLength += 2 + 2 * len(m.supportedCurves)
    numExtensions++
}
[...]
// embed curves
if len(m.supportedCurves) > 0 {
    // http://tools.ietf.org/html/rfc4492#section-5.5.1
    z[0] = byte(extensionSupportedCurves >> 8)
    z[1] = byte(extensionSupportedCurves)
    l: = 2 + 2 * len(m.supportedCurves)
    z[2] = byte(l >> 8)
    z[3] = byte(l)
    l -= 2
    z[4] = byte(l >> 8)
    z[5] = byte(l)
    z = z[6: ]
    for _, curve: = range m.supportedCurves {
        z[0] = byte(curve >> 8)
        z[1] = byte(curve)
        z = z[2: ]
    }
}
```
is reduced to the following in Golang's `crypto/tls/handshake_messages.go`:
```golang
if len(m.supportedCurves) > 0 {
    // RFC 4492, sections 5.1.1 and RFC 8446, Section 4.2.7
    b.AddUint16(extensionSupportedCurves)
    b.AddUint16LengthPrefixed(func(b * cryptobyte.Builder) {
        b.AddUint16LengthPrefixed(func(b * cryptobyte.Builder) {
            for _, curve: = range m.supportedCurves {
                b.AddUint16(uint16(curve))
            }
        })
    })
}
```

### Minor
Add a CLI option to explicitly scan in 1.2 or 1.3 ?