### PR TITLE
Update initca.New to load the provided config file

### DIFF
--- a/api/initca/initca.go
+++ b/api/initca/initca.go
@@ -41,7 +41,7 @@ func initialCAHandler(w http.ResponseWriter, r *http.Request) error {
 		return errors.NewBadRequest(err)
 	}
 
-	cert, _, key, err := initca.New(req)
+	cert, _, key, err := initca.New(req, nil)
 	if err != nil {
 		log.Warningf("failed to initialise new CA: %v", err)
 		return err

--- a/cli/gencert/gencert.go
+++ b/cli/gencert/gencert.go
@@ -73,7 +73,6 @@ func gencertMain(args []string, c cli.Config) error {
 	if c.CNOverride != "" {
 		req.CN = c.CNOverride
 	}
-
 	switch {
 	case c.IsCA:
 		var key, csrPEM, cert []byte
@@ -129,7 +128,6 @@ func gencertMain(args []string, c cli.Config) error {
 		}
 
 		s, err := sign.SignerFromConfig(c)
-
 		if err != nil {
 			return err
 		}

--- a/cli/gencert/gencert.go
+++ b/cli/gencert/gencert.go
@@ -4,11 +4,11 @@ package gencert
 import (
 	"encoding/json"
 	"errors"
-
 	"github.com/cloudflare/cfssl/api/generator"
 	"github.com/cloudflare/cfssl/cli"
 	"github.com/cloudflare/cfssl/cli/genkey"
 	"github.com/cloudflare/cfssl/cli/sign"
+	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/initca"
 	"github.com/cloudflare/cfssl/log"
@@ -73,6 +73,7 @@ func gencertMain(args []string, c cli.Config) error {
 	if c.CNOverride != "" {
 		req.CN = c.CNOverride
 	}
+
 	switch {
 	case c.IsCA:
 		var key, csrPEM, cert []byte
@@ -85,7 +86,11 @@ func gencertMain(args []string, c cli.Config) error {
 			}
 		} else {
 			log.Infof("generating a new CA key and certificate from CSR")
-			cert, csrPEM, key, err = initca.New(&req)
+			var caSigningConfig *config.Signing
+			if c.CFG != nil {
+				caSigningConfig = c.CFG.Signing
+			}
+			cert, csrPEM, key, err = initca.New(&req, caSigningConfig)
 			if err != nil {
 				return err
 			}
@@ -124,6 +129,7 @@ func gencertMain(args []string, c cli.Config) error {
 		}
 
 		s, err := sign.SignerFromConfig(c)
+
 		if err != nil {
 			return err
 		}

--- a/cli/gencert/gencert_test.go
+++ b/cli/gencert/gencert_test.go
@@ -1,6 +1,7 @@
 package gencert
 
 import (
+	"github.com/cloudflare/cfssl/config"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -213,5 +214,28 @@ func TestBadGencertMain(t *testing.T) {
 	if err == nil {
 		t.Fatal("Invalid remote, should reort error")
 	}
+}
 
+func TestGencertMainWithConfigLoading(t *testing.T) {
+
+	c := cli.Config{
+		// note: despite IsCA being re-specified in
+		IsCA:       true,
+		ConfigFile: "../../testdata/good_config_ca.json",
+	}
+
+	// loading the config is done in the entrypoint of the program, we have to fill c.CFG manually here
+	var err error
+	c.CFG, err = config.LoadFile(c.ConfigFile)
+	if c.ConfigFile != "" && err != nil {
+		t.Fatal("Failed to load config file:", err)
+	}
+
+	// test: this should use the config specified in "good_config_ca.json" (hence produce a 10-year cert)
+	err = gencertMain([]string{"../testdata/csr.json"}, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// this can be checked manually with `go test | cfssljson -bare ca - | cfssl certinfo -cert ca.pem | grep not_after`
 }

--- a/cli/gencert/gencert_test.go
+++ b/cli/gencert/gencert_test.go
@@ -2,11 +2,10 @@ package gencert
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"github.com/cloudflare/cfssl/certinfo"
 	"github.com/cloudflare/cfssl/config"
 	"io/ioutil"
-	"errors"
 	"math"
 	"os"
 	"testing"
@@ -309,8 +308,6 @@ func TestGencertMainWithConfigLoading(t *testing.T) {
 	if err != nil {
 		t.Fatal("Couldn't parse the produced cert", err)
 	}
-
-	fmt.Println(parsedCert)
 
 	HoursInAYear := float64(8766) // 365.25 * 24
 	expiryHoursInConfig := c.CFG.Signing.Default.Expiry.Hours()

--- a/cli/genkey/genkey.go
+++ b/cli/genkey/genkey.go
@@ -4,6 +4,7 @@ package genkey
 import (
 	"encoding/json"
 	"errors"
+	"github.com/cloudflare/cfssl/config"
 
 	"github.com/cloudflare/cfssl/cli"
 	"github.com/cloudflare/cfssl/csr"
@@ -47,7 +48,11 @@ func genkeyMain(args []string, c cli.Config) (err error) {
 
 	if c.IsCA {
 		var key, csrPEM, cert []byte
-		cert, csrPEM, key, err = initca.New(&req)
+		var caSigningConfig *config.Signing
+		if c.CFG != nil {
+			caSigningConfig = c.CFG.Signing
+		}
+		cert, csrPEM, key, err = initca.New(&req, caSigningConfig)
 		if err != nil {
 			return
 		}

--- a/cli/genkey/genkey_test.go
+++ b/cli/genkey/genkey_test.go
@@ -3,11 +3,14 @@ package genkey
 import (
 	"encoding/json"
 	"errors"
+	"github.com/cloudflare/cfssl/certinfo"
+	"github.com/cloudflare/cfssl/cli"
+	"github.com/cloudflare/cfssl/config"
 	"io/ioutil"
+	"math"
 	"os"
 	"testing"
-
-	"github.com/cloudflare/cfssl/cli"
+	"time"
 )
 
 type stdoutRedirect struct {
@@ -33,21 +36,21 @@ func (pipe *stdoutRedirect) readAll() ([]byte, error) {
 	return ioutil.ReadAll(pipe.r)
 }
 
-func checkResponse(out []byte) error {
+func checkResponse(out []byte) (map[string]interface{}, error) {
 	var response map[string]interface{}
 	if err := json.Unmarshal(out, &response); err != nil {
-		return err
+		return nil, err
 	}
 
 	if response["key"] == nil {
-		return errors.New("no key is outputted")
+		return nil, errors.New("no key is outputted")
 	}
 
 	if response["csr"] == nil {
-		return errors.New("no csr is outputted")
+		return nil, errors.New("no csr is outputted")
 	}
 
-	return nil
+	return response, nil
 }
 
 func TestGenkey(t *testing.T) {
@@ -56,28 +59,78 @@ func TestGenkey(t *testing.T) {
 	var err error
 
 	if pipe, err = newStdoutRedirect(); err != nil {
-		t.Fatal(err)
+		t.Fatal("Could not create stdout pipe; cannot run test.", err)
 	}
 	if err := genkeyMain([]string{"testdata/csr.json"}, cli.Config{}); err != nil {
 		t.Fatal(err)
 	}
 	if out, err = pipe.readAll(); err != nil {
-		t.Fatal(err)
+		t.Fatal("Couldn't read from stdout", err)
 	}
-	if err := checkResponse(out); err != nil {
-		t.Fatal(err)
+	if _, err := checkResponse(out); err != nil {
+		t.Fatal("Format on stdout is unexpected", err)
 	}
 
 	if pipe, err = newStdoutRedirect(); err != nil {
-		t.Fatal(err)
+		t.Fatal("Could not create stdout pipe; cannot run test.", err)
 	}
 	if err := genkeyMain([]string{"testdata/csr.json"}, cli.Config{IsCA: true}); err != nil {
 		t.Fatal(err)
 	}
 	if out, err = pipe.readAll(); err != nil {
+		t.Fatal("Couldn't read from stdout", err)
+	}
+	if _, err := checkResponse(out); err != nil {
+		t.Fatal("Format on stdout is unexpected", err)
+	}
+}
+
+func TestGenkeyWithConfigLoading(t *testing.T) {
+	var pipe *stdoutRedirect
+	var out []byte
+	var err error
+
+	if pipe, err = newStdoutRedirect(); err != nil {
+		t.Fatal("Could not create stdout pipe; cannot run test.", err)
+	}
+
+	c := cli.Config{
+		// note: despite IsCA being re-specified in ConfigFile, it also needs to be manually set in config
+		IsCA:       true,
+		ConfigFile: "../../testdata/good_config_ca.json",
+	}
+
+	// loading the config is done in the entrypoint of the program, we have to fill c.CFG manually here
+	c.CFG, err = config.LoadFile(c.ConfigFile)
+	if c.ConfigFile != "" && err != nil {
+		t.Fatal("Failed to load config file:", err)
+	}
+
+	if err := genkeyMain([]string{"testdata/csr.json"}, c); err != nil {
 		t.Fatal(err)
 	}
-	if err := checkResponse(out); err != nil {
-		t.Fatal(err)
+
+	if out, err = pipe.readAll(); err != nil {
+		t.Fatal("Couldn't read from stdout", err)
+	}
+	response, err := checkResponse(out)
+	if err != nil {
+		t.Fatal("Format on stdout is unexpected", err)
+	}
+
+	cert := []byte(response["cert"].(string))
+
+	parsedCert, err := certinfo.ParseCertificatePEM(cert)
+	if err != nil {
+		t.Fatal("Couldn't parse the produced cert", err)
+	}
+
+	HoursInAYear := float64(8766) // 365.25 * 24
+	expiryHoursInConfig := c.CFG.Signing.Default.Expiry.Hours()
+	expiryYearsInConfig := int(math.Ceil(expiryHoursInConfig / HoursInAYear))
+	certExpiryInYears := parsedCert.NotAfter.Year() - time.Now().Year()
+
+	if certExpiryInYears != expiryYearsInConfig {
+		t.Fatal("Expiry specified in Config file is", expiryYearsInConfig, "but cert has expiry", certExpiryInYears)
 	}
 }

--- a/initca/initca_test.go
+++ b/initca/initca_test.go
@@ -81,7 +81,7 @@ func TestInitCA(t *testing.T) {
 				KeyRequest: &param,
 				CA:         &caconfig,
 			}
-			certBytes, _, keyBytes, err := New(req)
+			certBytes, _, keyBytes, err := New(req, nil)
 			if err != nil {
 				t.Fatal("InitCA failed:", err)
 			}
@@ -126,8 +126,8 @@ func TestInitCA(t *testing.T) {
 				}
 			}
 
-			// Replace the default CAPolicy with a test (short expiry) version.
-			CAPolicy = func() *config.Signing {
+			// Replace the default DefaultCAPolicy with a test (short expiry) version.
+			DefaultCAPolicy = func() *config.Signing {
 				return &config.Signing{
 					Default: &config.SigningProfile{
 						Usage:        []string{"cert sign", "crl sign"},
@@ -143,7 +143,7 @@ func TestInitCA(t *testing.T) {
 			if err != nil {
 				t.Fatal("Signer Creation error:", err)
 			}
-			s.SetPolicy(CAPolicy())
+			s.SetPolicy(DefaultCAPolicy())
 
 			// Sign RSA and ECDSA customer CSRs.
 			for _, csrFile := range csrFiles {
@@ -192,7 +192,7 @@ func TestInvalidCAConfig(t *testing.T) {
 		CA:         &invalidCAConfig,
 	}
 
-	_, _, _, err := New(req)
+	_, _, _, err := New(req, nil)
 	if err == nil {
 		t.Fatal("InitCA with bad CAConfig should fail:", err)
 	}
@@ -215,7 +215,7 @@ func TestInvalidCryptoParams(t *testing.T) {
 			Hosts:      []string{hostname, "www." + hostname},
 			KeyRequest: &invalidParam,
 		}
-		_, _, _, err := New(req)
+		_, _, _, err := New(req, nil)
 		if err == nil {
 			t.Fatal("InitCA with bad params should fail:", err)
 		}

--- a/testdata/good_config_ca.json
+++ b/testdata/good_config_ca.json
@@ -1,0 +1,25 @@
+{
+    "signing": {
+        "default": {
+            "usages": [
+                "cert sign",
+                "crl sign"
+            ],
+            "ca_constraint" : {
+                "is_ca": true
+            },
+            "expiry": "87600h"
+        },
+        "profiles": {
+            "www": {
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "server auth"
+                ],
+                "name_whitelist": "^.*\\.cloudflare.com$",
+                "expiry": "87600h"
+            }
+        }
+    }
+}

--- a/testdata/good_config_ca.json
+++ b/testdata/good_config_ca.json
@@ -8,7 +8,7 @@
             "ca_constraint" : {
                 "is_ca": true
             },
-            "expiry": "87600h"
+            "expiry": "87660h"
         },
         "profiles": {
             "www": {

--- a/transport/ca/localca/signer.go
+++ b/transport/ca/localca/signer.go
@@ -129,13 +129,16 @@ func ExampleSigningConfig() *config.Signing {
 				"server auth", "client auth",
 				"signing", "key encipherment",
 			},
+			CAConstraint: config.CAConstraint{
+				IsCA: true,
+			},
 		},
 	}
 }
 
 // New generates a new CA from a certificate request and signing profile.
 func New(req *csr.CertificateRequest, profiles *config.Signing) (*CA, error) {
-	certPEM, _, keyPEM, err := initca.New(req)
+	certPEM, _, keyPEM, err := initca.New(req, profiles)
 	if err != nil {
 		return nil, err
 	}

--- a/transport/ca/localca/signer_test.go
+++ b/transport/ca/localca/signer_test.go
@@ -82,7 +82,7 @@ func TestEncodePEM(t *testing.T) {
 
 func TestLoadSigner(t *testing.T) {
 	lca := &CA{}
-	certPEM, csrPEM, keyPEM, err := initca.New(ExampleRequest())
+	certPEM, csrPEM, keyPEM, err := initca.New(ExampleRequest(), nil)
 	assert.NoErrorT(t, err)
 
 	_, err = lca.CACertificate()


### PR DESCRIPTION
Hi all,

This follows issue https://github.com/cloudflare/cfssl/issues/1034. When doing `cat request.json | ./cfssl gencert -initca -config=./ca-config.json`, the CA parameters were not used despite the appearances (a hard-coded profile was loaded from `initca/initca.go:224`).

This PR changes this so that:
- the default behavior is unchanged
- when a `signingProfile` is provided through the CLI, it is used instead of the default

Example usage:
```
$ cat ca-config.json
{
  "signing": {
    "default": {
    	"usages": [
          "cert sign",
          "crl sign"
        ],
        "ca_constraint" : {
        	"is_ca": true
        },
        "expiry": "87600h"
    },
    "profiles": {}
  }
}
```
To note:
- 10years expiry instead of the default 5
- since this config replaces the default profile, `ca_constraint.is_ca=true` is mandatory to use this option (otherwise, this outputs the already-used error `InvalidPolicy`)

```
$ cat request.json
{
  "CN": "test",
  "key": {
    "algo": "rsa",
    "size": 4096
  },
  "names": [
    {
      "C": "CA",
      "O": "test",
      "OU": "test"
    }
  ]
}
```

A 10-year certificate is produced as expected.
```
$ cat request.json | ./cfssl gencert -initca -config=./ca-config.json - | cfssljson -bare ca - 
$ cfssl certinfo -cert ca.pem | grep not
  "not_before": "2020-04-23T15:24:00Z",
  "not_after": "2030-04-21T15:24:00Z",

```

Thanks!